### PR TITLE
Support optional dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,21 @@
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+MIT License
+
+Copyright (c) 2023 Reuben Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,37 @@
 Device test core library for running tests against a device using a generic interface, e.g. SSH, Docker, or some other custom type.
 
 This library can be used to build plugins for different test frameworks such as pytest and Robot Framework.
+
+The project's goal is to create a common interface for interacting with devices under test. The adapter normalize the interface enabling you to write tests which are independent of the device interface being used (e.g. docker, ssh, local etc.).
+
+## Installing from project
+
+The `device-test-core` package includes several device adapters, each with their own dependencies.
+
+Below shows how to either install all adapters, or just the adapters you are interested in. This allows you to keep the dependencies to a minimum.
+
+### Installing all adapters
+
+```
+pip3 install "device-test-core[all] @ git+https://github.com/reubenmiller/device-test-core.git"
+```
+
+### Installing specific adapters
+
+#### docker adapter
+
+```
+pip3 install "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git"
+```
+
+#### ssh adapter
+
+```
+pip3 install "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git"
+```
+
+#### local adapter
+
+```
+pip3 install "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,9 @@ classifiers = [
 ]
 dynamic = ["version", "readme"]
 dependencies = [
-    "python-dotenv"
-  #"python-dotenv >= 0.20.0, < 0.21.0",
-  #"randomname >= 0.1.5, < 0.2.0",
-  #"tenacity >= 8.1.0, < 9.0.0",
+  "python-dotenv >= 0.20.0, < 0.21.0",
+  "randomname >= 0.1.5, < 0.2.0",
+  "tenacity >= 8.1.0, < 9.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=61",
     "wheel",
-    "setuptools_scm>=6.2",
+    "setuptools-scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+all = [
+    "device-test-core[ssh]",
+    "device-test-core[docker]",
+    "device-test-core[local]",
+]
 ssh = [
     "paramiko >= 2.12.0, < 2.13.0",
     "scp >= 0.14.4, < 0.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ classifiers = [
 ]
 dynamic = ["version", "dependencies", "readme"]
 dependencies = [
-  "python-dotenv >= 0.20.0, < 0.21.0",
-  "randomname >= 0.1.5, < 0.2.0",
-  "tenacity >= 8.1.0, < 9.0.0",
+    "python-dotenv",
+  #"python-dotenv >= 0.20.0, < 0.21.0",
+  #"randomname >= 0.1.5, < 0.2.0",
+  #"tenacity >= 8.1.0, < 9.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "device_test_core/_version.py"
 
-[tool.setuptools.dynamic]
-readme = {file = ["README.md"]}
+#[tool.setuptools.dynamic]
+#readme = {file = ["README.md"]}
 
 [project]
 name = "device_test_core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=61",
     "wheel",
     "setuptools_scm>=6.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "device_test_core/_version.py"
 
-#[tool.setuptools.dynamic]
-#readme = {file = ["README.md"]}
+[tool.setuptools.dynamic]
+readme = {file = ["README.md"]}
 
 [project]
 name = "device_test_core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+[build-system]
+requires = [
+    "setuptools>=45",
+    "wheel",
+    "setuptools_scm>=6.2",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "device_test_core/_version.py"
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.md"]}
+
 [project]
 name = "device_test_core"
 description = "Device test library"
@@ -28,17 +42,3 @@ local = []
 docker = [
     'docker >= 6.0.1, < 6.1.0'
 ]
-
-[build-system]
-requires = [
-    "setuptools>=45",
-    "wheel",
-    "setuptools_scm>=6.2",
-]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-write_to = "device_test_core/_version.py"
-
-[tool.setuptools.dynamic]
-readme = {file = ["README.md"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,22 +23,17 @@ classifiers = [
 ]
 dynamic = ["version", "dependencies", "readme"]
 dependencies = [
-  'python-dotenv >= 0.20.0, < 0.21.0',
-  'randomname >= 0.1.5, < 0.2.0',
-  'tenacity >= 8.1.0, < 9.0.0',
-  # 'docker[ssh] >= 4.2.2, < 5',
-
-  # Conditional
-  #'backports.shutil_get_terminal_size == 1.0.0; python_version < "3.3"',
-  #'colorama >= 0.4, < 1; sys_platform == "win32"',
+  "python-dotenv >= 0.20.0, < 0.21.0",
+  "randomname >= 0.1.5, < 0.2.0",
+  "tenacity >= 8.1.0, < 9.0.0",
 ]
 
 [project.optional-dependencies]
 ssh = [
-    'paramiko >= 2.12.0, < 2.13.0',
-    'scp >= 0.14.4, < 0.15.0',
+    "paramiko >= 2.12.0, < 2.13.0",
+    "scp >= 0.14.4, < 0.15.0",
 ]
 local = []
 docker = [
-    'docker >= 6.0.1, < 6.1.0'
+    "docker >= 6.0.1, < 6.1.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-dynamic = ["version", "dependencies", "readme"]
+dynamic = ["version", "readme"]
 dependencies = [
-    "python-dotenv",
+    "python-dotenv"
   #"python-dotenv >= 0.20.0, < 0.21.0",
   #"randomname >= 0.1.5, < 0.2.0",
   #"tenacity >= 8.1.0, < 9.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,34 @@
+[project]
+name = "device_test_core"
+description = "Device test library"
+requires-python = ">=3.7"
+keywords = ["device", "testing"]
+license = {text = "MIT"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
+dynamic = ["version", "dependencies", "readme"]
+dependencies = [
+  'python-dotenv >= 0.20.0, < 0.21.0',
+  'randomname >= 0.1.5, < 0.2.0',
+  'tenacity >= 8.1.0, < 9.0.0',
+  # 'docker[ssh] >= 4.2.2, < 5',
+
+  # Conditional
+  #'backports.shutil_get_terminal_size == 1.0.0; python_version < "3.3"',
+  #'colorama >= 0.4, < 1; sys_platform == "win32"',
+]
+
+[project.optional-dependencies]
+ssh = [
+    'paramiko >= 2.12.0, < 2.13.0',
+    'scp >= 0.14.4, < 0.15.0',
+]
+local = []
+docker = [
+    'docker >= 6.0.1, < 6.1.0'
+]
+
 [build-system]
 requires = [
     "setuptools>=45",
@@ -9,17 +40,5 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "device_test_core/_version.py"
 
-[project]
-name = "device_test_core"
-description = "Core test library for Cumulocity IoT"
-requires-python = ">=3.8"
-keywords = ["device", "testing"]
-license = {text = "MPL-2.0"}
-classifiers = [
-    "Programming Language :: Python :: 3",
-]
-dynamic = ["version", "dependencies", "readme"]
-
 [tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
 readme = {file = ["README.md"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-docker>=6.0.1
-paramiko==2.12.0
-scp==0.14.4
-python-dotenv~=0.20.0
-randomname~=0.1.5
-tenacity~=8.1.0


### PR DESCRIPTION
Reduce the number of required dependencies by allowing users to only install the dependencies for the specific adapters that they wish to use.

* change to MIT license
* add optional dependencies for each adapters
* readme instructions on how to install the optional adapters
* manage requirements via pyproject.toml instead of the `requirements.txt`
* add support for python >=3.7