### PR TITLE
fix(docker): don't log output when log_output is set to False

### DIFF
--- a/device_test_core/docker/device.py
+++ b/device_test_core/docker/device.py
@@ -186,8 +186,6 @@ class DockerDeviceAdapter(DeviceAdapter):
                 to_str(stdout) or "<<empty>>",
                 to_str(stderr) or "<<empty>>",
             )
-        else:
-            log.info("cmd: %s, exit code: %d", run_cmd, exit_code)
 
         return CmdOutput(stdout=stdout, stderr=stderr, return_code=exit_code)
 


### PR DESCRIPTION
Fix inconsistency where the `log_output` option of the `execute_command` as not respected in the Docker adapter.