### PR TITLE
fix: update docker-py to python requests incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ ssh = [
 ]
 local = []
 docker = [
-    "docker >= 7.0.0, < 7.1.0"
+    "docker >= 7.1.0, < 7.2.0"
 ]


### PR DESCRIPTION
Update the docker-py dependency to fix the following error when trying to configure the docker client:

```
DockerException: Error while fetching server API version: Not supported URL scheme http+docker
```