### PR TITLE
chore: update dependencies and drop support for python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,34 @@
 [build-system]
 requires = [
-    "setuptools>=61",
-    "wheel",
-    "setuptools-scm[toml]>=6.2",
+    "setuptools>=75",
+    "wheel>=0.43.0",
+    "setuptools-scm[toml]>=8",
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "device_test_core/_version.py"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["device_test_core*"]
+
 [project]
 name = "device_test_core"
 description = "Device test library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["device", "testing"]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dynamic = ["version"]
 dependencies = [
-  "python-dotenv >= 1.0.0, < 1.1.0",
+  "python-dotenv >= 1.0.0, < 2.0.0",
   "randomname >= 0.1.5, < 0.2.0",
-  "tenacity >= 8.1.0, < 9.0.0",
-  "dateparser >= 1.2.0, < 1.3.0",
+  "tenacity >= 9.0.0, < 10.0.0",
+  "dateparser >= 1.3.0, < 1.4.0",
 ]
 
 [project.optional-dependencies]
@@ -34,8 +38,8 @@ all = [
     "device-test-core[local]",
 ]
 ssh = [
-    "paramiko >= 3.5, < 3.6",
-    "scp >= 0.14.4, < 0.15.0",
+    "paramiko >= 4.0, < 4.1",
+    "scp >= 0.15.0, < 0.16.0",
 ]
 local = []
 docker = [


### PR DESCRIPTION
Update the dependencies and fix associated project definitions to remove warnings.

Support for python 3.9 is now dropped as it is EOL.