### PR TITLE
fix(docker): use custom socket handling to fix a socket buffer issue in docker-py

### DIFF
--- a/device_test_core/utils.py
+++ b/device_test_core/utils.py
@@ -20,19 +20,25 @@ def generate_name(prefix: Optional[str] = None, sep="_") -> str:
     return name
 
 
-def to_str(value: Any, encoding: str = "utf8") -> str:
+def to_str(value: Any, encoding: str = "utf8", errors: str = "replace") -> str:
     """Convert a value to a string. If the input is bytes, then decode it
     using the given encoding.
+
+    Non-decodable bytes are replaced with the Unicode replacement character
+    (U+FFFD) by default (errors='replace'), so callers never receive a
+    UnicodeDecodeError. Pass errors='strict' if you need to detect binary
+    content explicitly.
 
     Args:
         value (Any): Input to be decoded to a string
         encoding (str): Encoding if the input is bytes. Defaults to utf8
+        errors (str): Error handler for bytes.decode(). Defaults to 'replace'
 
     Returns:
         str: value decoded as a string
     """
     if hasattr(value, "decode"):
-        return value.decode(encoding)
+        return value.decode(encoding, errors=errors)
 
     if not value:
         return ""


### PR DESCRIPTION
Unfortunately this refactoring is an overcomplication, however it seems to have a positive effect on the bug where the execute_command can sometimes return empty stdout and stderr (most notably in the Github runner).