### PR TITLE
feat: Show microsecond precision in journald logs

### DIFF
--- a/device_test_core/adapter.py
+++ b/device_test_core/adapter.py
@@ -248,7 +248,7 @@ class DeviceAdapter(ABC):
         Returns:
             List[str]: List of log entries
         """
-        cmd = "journalctl --lines 100000 --no-pager -u 'tedge*' -u 'c8y*' -u mosquitto -u 'mqtt-logger'"
+        cmd = "journalctl -o short-precise --lines 100000 --no-pager -u 'tedge*' -u 'c8y*' -u mosquitto -u 'mqtt-logger'"
 
         since = since if since is not None else self.test_start_time
         output = []


### PR DESCRIPTION
Use the [`short-precise`](https://www.freedesktop.org/software/systemd/man/latest/journalctl.html#short-precise) output option to show timestamp up to microsecond precision in journald logs.

I am debugging an issue where my hypothesis is that after tedge-mapper-c8y is stopped in the test and the test uses Cumulocity library to delete devices, Cumulocity might still respond to in-flight MQTT messages, which may create devices after I've deleted them.

However, logs from MQTT messages and tedge-mapper-c8y have sub-second precision, but from mosquitto do not, which is annoying because mosquitto reports when we receive Cumulocity PUBACKs. This option enables sub-second precision for these logs.